### PR TITLE
callbacks -> handlers

### DIFF
--- a/lua/folding.lua
+++ b/lua/folding.lua
@@ -35,6 +35,10 @@ function M.setup_plugin()
 
 
       if server_supports_folding then
+        -- for backwards compatibility
+        if client.config.callbacks then
+          client.config.callbacks['textDocument/foldingRange'] = M.fold_handler
+        end
         client.config.handlers['textDocument/foldingRange'] = M.fold_handler
         api.nvim_command('augroup LspFolding')
         api.nvim_command('autocmd!')

--- a/lua/folding.lua
+++ b/lua/folding.lua
@@ -35,7 +35,7 @@ function M.setup_plugin()
 
 
       if server_supports_folding then
-        client.config.callbacks['textDocument/foldingRange'] = M.fold_callback
+        client.config.handlers['textDocument/foldingRange'] = M.fold_handler
         api.nvim_command('augroup LspFolding')
         api.nvim_command('autocmd!')
         api.nvim_command('autocmd BufWritePost <buffer> lua require"folding".update_folds()')
@@ -74,7 +74,7 @@ function M.debug_folds()
 end
 
 
-function M.fold_callback(_, _, result)
+function M.fold_handler(_, _, result)
   for _, fold in ipairs(result) do
     fold['startLine'] = M.adjust_foldstart(fold['startLine'])
     fold['endLine'] = M.adjust_foldend(fold['endLine'])

--- a/lua/folding.lua
+++ b/lua/folding.lua
@@ -39,7 +39,9 @@ function M.setup_plugin()
         if client.config.callbacks then
           client.config.callbacks['textDocument/foldingRange'] = M.fold_handler
         end
-        client.config.handlers['textDocument/foldingRange'] = M.fold_handler
+        if client.config.handlers then
+          client.config.handlers['textDocument/foldingRange'] = M.fold_handler
+        end
         api.nvim_command('augroup LspFolding')
         api.nvim_command('autocmd!')
         api.nvim_command('autocmd BufWritePost <buffer> lua require"folding".update_folds()')


### PR DESCRIPTION
Per the changes in https://github.com/neovim/neovim/pull/12655, this will fix folding-nvim to use `handlers` instead.