### PR TITLE
Avoid folding when result is nil

### DIFF
--- a/lua/folding.lua
+++ b/lua/folding.lua
@@ -86,7 +86,7 @@ function M.fold_handler(_, _, result, _, bufnr)
   local current_bufnr = api.nvim_get_current_buf()
   -- Discard the folding result if buffer focus has changed since the request was
   -- done.
-  if current_bufnr == bufnr then
+  if current_bufnr == bufnr and result then
     for _, fold in ipairs(result) do
       fold['startLine'] = M.adjust_foldstart(fold['startLine'])
       fold['endLine'] = M.adjust_foldend(fold['endLine'])


### PR DESCRIPTION

I ran into the following error messages when using a language server that does not support folding.

```
lsp-folding: efm does not provide folding requests
Error executing vim.schedule lua callback: ...nvim/site/pack/packer/start/folding-nvim/lua/folding.lua:90: bad argument #1
to 'ipairs' (table expected, got nil)
```

This seems to be the most straight forward fix for now. Please let me know what you think.

Thank you.
